### PR TITLE
Fixed bug: empty input still results in searchbar being pushed up

### DIFF
--- a/MovieMatcher/Views/SearchView.xaml.cs
+++ b/MovieMatcher/Views/SearchView.xaml.cs
@@ -25,11 +25,12 @@ namespace MovieMatcher.Views
         //when the searchbutton is clicked, this function will fire filling the listbox with items
         private void SearchButton_Clicked(object sender, RoutedEventArgs e)
         {
-            Grid.SetRow(SearchBar, 0);
-            ResultBox.Items.Clear();
 
             if (!ApiService.Search(searchTxt.Text, out var getMovieResult, GreaterThan18(UserStore.birthYear ?? DateTime.Now)))
                 return;
+
+            Grid.SetRow(SearchBar, 0);
+            ResultBox.Items.Clear();
 
             if (getMovieResult?.results == null || getMovieResult.results.Count == 0)
             {

--- a/MovieMatcher/Views/SearchView.xaml.cs
+++ b/MovieMatcher/Views/SearchView.xaml.cs
@@ -25,7 +25,6 @@ namespace MovieMatcher.Views
         //when the searchbutton is clicked, this function will fire filling the listbox with items
         private void SearchButton_Clicked(object sender, RoutedEventArgs e)
         {
-
             if (!ApiService.Search(searchTxt.Text, out var getMovieResult, GreaterThan18(UserStore.birthYear ?? DateTime.Now)))
                 return;
 


### PR DESCRIPTION
-when search clicked on empty input the searchbar still moved up showing an empty screen. this shouldn't happen and thus it has been fixed